### PR TITLE
build: reference correct Icon in notation-specialized packages

### DIFF
--- a/Unity.Mathematics.Text.Json.ArrayNotation/Unity.Mathematics.Text.Json.ArrayNotation.csproj
+++ b/Unity.Mathematics.Text.Json.ArrayNotation/Unity.Mathematics.Text.Json.ArrayNotation.csproj
@@ -10,7 +10,7 @@
     <Title>Unity.Mathematics Text.Json Array Notation</Title>
     <Description>System.Text.Json serializers for Unity.Mathematics types, serializing data as arrays</Description>
     <PackageTags>Unity;Mathematics;System.Text.Json;Json</PackageTags>
-    <PackageIcon>Icon.png</PackageIcon>
+    <PackageIcon>IconArrayNotation.png</PackageIcon>
     <PackageIconUrl>https://raw.github.com/KageKirin/Unity.Mathematics.Text.Json/IconArrayNotation.png</PackageIconUrl>
   </PropertyGroup>
 

--- a/Unity.Mathematics.Text.Json.ObjectNotation/Unity.Mathematics.Text.Json.ObjectNotation.csproj
+++ b/Unity.Mathematics.Text.Json.ObjectNotation/Unity.Mathematics.Text.Json.ObjectNotation.csproj
@@ -10,7 +10,7 @@
     <Title>Unity.Mathematics Text.Json Object Notation</Title>
     <Description>System.Text.Json serializers for Unity.Mathematics types, serializing data as objects</Description>
     <PackageTags>Unity;Mathematics;System.Text.Json;Json</PackageTags>
-    <PackageIcon>Icon.png</PackageIcon>
+    <PackageIcon>IconObjectNotation.png</PackageIcon>
     <PackageIconUrl>https://raw.github.com/KageKirin/Unity.Mathematics.Text.Json/IconObjectNotation.png</PackageIconUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
- **build: reference array notation Icon.png in Unity.Mathematics.Text.Json.ArrayNotation.csproj**
- **build: reference object notation Icon.png in Unity.Mathematics.Text.Json.ObjectNotation.csproj**
