### PR TITLE
refactor: set static JsonSerializerOptions instances to be readonly

### DIFF
--- a/Unity.Mathematics.Text.Json.ArrayNotation/ArrayNotationJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json.ArrayNotation/ArrayNotationJsonSerializerOptions.cs
@@ -5,7 +5,7 @@ namespace Unity.Mathematics.Text.Json;
 
 public static class Profile
 {
-    public static JsonSerializerOptions JsonSerializerOptions =
+    public static readonly JsonSerializerOptions JsonSerializerOptions =
         new()
         {
             MaxDepth = 1024,

--- a/Unity.Mathematics.Text.Json.ObjectNotation/ObjectNotationJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json.ObjectNotation/ObjectNotationJsonSerializerOptions.cs
@@ -5,7 +5,7 @@ namespace Unity.Mathematics.Text.Json;
 
 public static class Profile
 {
-    public static JsonSerializerOptions JsonSerializerOptions =
+    public static readonly JsonSerializerOptions JsonSerializerOptions =
         new()
         {
             MaxDepth = 1024,

--- a/Unity.Mathematics.Text.Json/JsonSerializerOptions/ArrayJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json/JsonSerializerOptions/ArrayJsonSerializerOptions.cs
@@ -4,7 +4,7 @@ namespace Unity.Mathematics.Text.Json;
 
 public static class Array
 {
-    public static JsonSerializerOptions JsonSerializerOptions =
+    public static readonly JsonSerializerOptions JsonSerializerOptions =
         new()
         {
             MaxDepth = 1024,

--- a/Unity.Mathematics.Text.Json/JsonSerializerOptions/DefaultJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json/JsonSerializerOptions/DefaultJsonSerializerOptions.cs
@@ -4,5 +4,6 @@ namespace Unity.Mathematics.Text.Json;
 
 public static class Default
 {
-    public static JsonSerializerOptions JsonSerializerOptions => Array.JsonSerializerOptions;
+    public static readonly JsonSerializerOptions JsonSerializerOptions =
+        Array.JsonSerializerOptions;
 }

--- a/Unity.Mathematics.Text.Json/JsonSerializerOptions/ObjectJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json/JsonSerializerOptions/ObjectJsonSerializerOptions.cs
@@ -4,7 +4,7 @@ namespace Unity.Mathematics.Text.Json;
 
 public static class Object
 {
-    public static JsonSerializerOptions JsonSerializerOptions =
+    public static readonly JsonSerializerOptions JsonSerializerOptions =
         new()
         {
             MaxDepth = 1024,


### PR DESCRIPTION
- **refactor (Unity.Mathematics.Text.Json): set Default.JsonSerializerOptions to be readonly**
- **refactor (Unity.Mathematics.Text.Json): set Array.JsonSerializerOptions to be readonly**
- **refactor (Unity.Mathematics.Text.Json): set Object.JsonSerializerOptions to be readonly**
- **refactor (Unity.Mathematics.Text.Json.ArrayNotation): set Profile.JsonSerializerOptions to be readonly**
- **refactor (Unity.Mathematics.Text.Json.ObjectNotation): set Profile.JsonSerializerOptions to be readonly**
