### PR TITLE
refactor: create JsonSerializerOptions instances from factory methods

### DIFF
--- a/Unity.Mathematics.Text.Json.ArrayNotation/ArrayNotationJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json.ArrayNotation/ArrayNotationJsonSerializerOptions.cs
@@ -6,73 +6,75 @@ namespace Unity.Mathematics.Text.Json;
 public static class Profile
 {
     public static readonly JsonSerializerOptions JsonSerializerOptions =
-        new()
-        {
-            MaxDepth = 1024,
-            WriteIndented = true,
-            Converters =
-            {
-                new Float2JsonConverter(),
-                new Float3JsonConverter(),
-                new Float4JsonConverter(),
-                new QuaternionJsonConverter(),
-                new Float2x2JsonConverter(),
-                new Float2x3JsonConverter(),
-                new Float2x4JsonConverter(),
-                new Float3x2JsonConverter(),
-                new Float3x3JsonConverter(),
-                new Float3x4JsonConverter(),
-                new Float4x2JsonConverter(),
-                new Float4x3JsonConverter(),
-                new Float4x4JsonConverter(),
-                new Int2JsonConverter(),
-                new Int3JsonConverter(),
-                new Int4JsonConverter(),
-                new Int2x2JsonConverter(),
-                new Int2x3JsonConverter(),
-                new Int2x4JsonConverter(),
-                new Int3x2JsonConverter(),
-                new Int3x3JsonConverter(),
-                new Int3x4JsonConverter(),
-                new Int4x2JsonConverter(),
-                new Int4x3JsonConverter(),
-                new Int4x4JsonConverter(),
-                new Uint2JsonConverter(),
-                new Uint3JsonConverter(),
-                new Uint4JsonConverter(),
-                new Uint2x2JsonConverter(),
-                new Uint2x3JsonConverter(),
-                new Uint2x4JsonConverter(),
-                new Uint3x2JsonConverter(),
-                new Uint3x3JsonConverter(),
-                new Uint3x4JsonConverter(),
-                new Uint4x2JsonConverter(),
-                new Uint4x3JsonConverter(),
-                new Uint4x4JsonConverter(),
-                new Double2JsonConverter(),
-                new Double3JsonConverter(),
-                new Double4JsonConverter(),
-                new Double2x2JsonConverter(),
-                new Double2x3JsonConverter(),
-                new Double2x4JsonConverter(),
-                new Double3x2JsonConverter(),
-                new Double3x3JsonConverter(),
-                new Double3x4JsonConverter(),
-                new Double4x2JsonConverter(),
-                new Double4x3JsonConverter(),
-                new Double4x4JsonConverter(),
-                new Bool2JsonConverter(),
-                new Bool3JsonConverter(),
-                new Bool4JsonConverter(),
-                new Bool2x2JsonConverter(),
-                new Bool2x3JsonConverter(),
-                new Bool2x4JsonConverter(),
-                new Bool3x2JsonConverter(),
-                new Bool3x3JsonConverter(),
-                new Bool3x4JsonConverter(),
-                new Bool4x2JsonConverter(),
-                new Bool4x3JsonConverter(),
-                new Bool4x4JsonConverter()
-            }
-        };
+        CreateJsonSerializerOptions();
+
+    private static JsonSerializerOptions CreateJsonSerializerOptions()
+    {
+        JsonSerializerOptions jsonSerializerOptions =
+            new() { MaxDepth = 1024, WriteIndented = true, };
+
+        jsonSerializerOptions.Converters.Add(new Float2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new QuaternionJsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x4JsonConverter());
+
+        return jsonSerializerOptions;
+    }
 }

--- a/Unity.Mathematics.Text.Json.ObjectNotation/ObjectNotationJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json.ObjectNotation/ObjectNotationJsonSerializerOptions.cs
@@ -6,73 +6,75 @@ namespace Unity.Mathematics.Text.Json;
 public static class Profile
 {
     public static readonly JsonSerializerOptions JsonSerializerOptions =
-        new()
-        {
-            MaxDepth = 1024,
-            WriteIndented = true,
-            Converters =
-            {
-                new Float2JsonConverter(),
-                new Float3JsonConverter(),
-                new Float4JsonConverter(),
-                new QuaternionJsonConverter(),
-                new Float2x2JsonConverter(),
-                new Float2x3JsonConverter(),
-                new Float2x4JsonConverter(),
-                new Float3x2JsonConverter(),
-                new Float3x3JsonConverter(),
-                new Float3x4JsonConverter(),
-                new Float4x2JsonConverter(),
-                new Float4x3JsonConverter(),
-                new Float4x4JsonConverter(),
-                new Int2JsonConverter(),
-                new Int3JsonConverter(),
-                new Int4JsonConverter(),
-                new Int2x2JsonConverter(),
-                new Int2x3JsonConverter(),
-                new Int2x4JsonConverter(),
-                new Int3x2JsonConverter(),
-                new Int3x3JsonConverter(),
-                new Int3x4JsonConverter(),
-                new Int4x2JsonConverter(),
-                new Int4x3JsonConverter(),
-                new Int4x4JsonConverter(),
-                new Uint2JsonConverter(),
-                new Uint3JsonConverter(),
-                new Uint4JsonConverter(),
-                new Uint2x2JsonConverter(),
-                new Uint2x3JsonConverter(),
-                new Uint2x4JsonConverter(),
-                new Uint3x2JsonConverter(),
-                new Uint3x3JsonConverter(),
-                new Uint3x4JsonConverter(),
-                new Uint4x2JsonConverter(),
-                new Uint4x3JsonConverter(),
-                new Uint4x4JsonConverter(),
-                new Double2JsonConverter(),
-                new Double3JsonConverter(),
-                new Double4JsonConverter(),
-                new Double2x2JsonConverter(),
-                new Double2x3JsonConverter(),
-                new Double2x4JsonConverter(),
-                new Double3x2JsonConverter(),
-                new Double3x3JsonConverter(),
-                new Double3x4JsonConverter(),
-                new Double4x2JsonConverter(),
-                new Double4x3JsonConverter(),
-                new Double4x4JsonConverter(),
-                new Bool2JsonConverter(),
-                new Bool3JsonConverter(),
-                new Bool4JsonConverter(),
-                new Bool2x2JsonConverter(),
-                new Bool2x3JsonConverter(),
-                new Bool2x4JsonConverter(),
-                new Bool3x2JsonConverter(),
-                new Bool3x3JsonConverter(),
-                new Bool3x4JsonConverter(),
-                new Bool4x2JsonConverter(),
-                new Bool4x3JsonConverter(),
-                new Bool4x4JsonConverter()
-            }
-        };
+        CreateJsonSerializerOptions();
+
+    private static JsonSerializerOptions CreateJsonSerializerOptions()
+    {
+        JsonSerializerOptions jsonSerializerOptions =
+            new() { MaxDepth = 1024, WriteIndented = true, };
+
+        jsonSerializerOptions.Converters.Add(new Float2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new QuaternionJsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x4JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x2JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x3JsonConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x4JsonConverter());
+
+        return jsonSerializerOptions;
+    }
 }

--- a/Unity.Mathematics.Text.Json/JsonSerializerOptions/ArrayJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json/JsonSerializerOptions/ArrayJsonSerializerOptions.cs
@@ -5,73 +5,75 @@ namespace Unity.Mathematics.Text.Json;
 public static class Array
 {
     public static readonly JsonSerializerOptions JsonSerializerOptions =
-        new()
-        {
-            MaxDepth = 1024,
-            WriteIndented = true,
-            Converters =
-            {
-                new Float2JsonArrayConverter(),
-                new Float3JsonArrayConverter(),
-                new Float4JsonArrayConverter(),
-                new QuaternionJsonArrayConverter(),
-                new Float2x2JsonArrayConverter(),
-                new Float2x3JsonArrayConverter(),
-                new Float2x4JsonArrayConverter(),
-                new Float3x2JsonArrayConverter(),
-                new Float3x3JsonArrayConverter(),
-                new Float3x4JsonArrayConverter(),
-                new Float4x2JsonArrayConverter(),
-                new Float4x3JsonArrayConverter(),
-                new Float4x4JsonArrayConverter(),
-                new Int2JsonArrayConverter(),
-                new Int3JsonArrayConverter(),
-                new Int4JsonArrayConverter(),
-                new Int2x2JsonArrayConverter(),
-                new Int2x3JsonArrayConverter(),
-                new Int2x4JsonArrayConverter(),
-                new Int3x2JsonArrayConverter(),
-                new Int3x3JsonArrayConverter(),
-                new Int3x4JsonArrayConverter(),
-                new Int4x2JsonArrayConverter(),
-                new Int4x3JsonArrayConverter(),
-                new Int4x4JsonArrayConverter(),
-                new Uint2JsonArrayConverter(),
-                new Uint3JsonArrayConverter(),
-                new Uint4JsonArrayConverter(),
-                new Uint2x2JsonArrayConverter(),
-                new Uint2x3JsonArrayConverter(),
-                new Uint2x4JsonArrayConverter(),
-                new Uint3x2JsonArrayConverter(),
-                new Uint3x3JsonArrayConverter(),
-                new Uint3x4JsonArrayConverter(),
-                new Uint4x2JsonArrayConverter(),
-                new Uint4x3JsonArrayConverter(),
-                new Uint4x4JsonArrayConverter(),
-                new Double2JsonArrayConverter(),
-                new Double3JsonArrayConverter(),
-                new Double4JsonArrayConverter(),
-                new Double2x2JsonArrayConverter(),
-                new Double2x3JsonArrayConverter(),
-                new Double2x4JsonArrayConverter(),
-                new Double3x2JsonArrayConverter(),
-                new Double3x3JsonArrayConverter(),
-                new Double3x4JsonArrayConverter(),
-                new Double4x2JsonArrayConverter(),
-                new Double4x3JsonArrayConverter(),
-                new Double4x4JsonArrayConverter(),
-                new Bool2JsonArrayConverter(),
-                new Bool3JsonArrayConverter(),
-                new Bool4JsonArrayConverter(),
-                new Bool2x2JsonArrayConverter(),
-                new Bool2x3JsonArrayConverter(),
-                new Bool2x4JsonArrayConverter(),
-                new Bool3x2JsonArrayConverter(),
-                new Bool3x3JsonArrayConverter(),
-                new Bool3x4JsonArrayConverter(),
-                new Bool4x2JsonArrayConverter(),
-                new Bool4x3JsonArrayConverter(),
-                new Bool4x4JsonArrayConverter()
-            }
-        };
+        CreateJsonArraySerializerOptions();
+
+    private static JsonSerializerOptions CreateJsonArraySerializerOptions()
+    {
+        JsonSerializerOptions jsonSerializerOptions =
+            new() { MaxDepth = 1024, WriteIndented = true, };
+
+        jsonSerializerOptions.Converters.Add(new Float2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new QuaternionJsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x4JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x2JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x3JsonArrayConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x4JsonArrayConverter());
+
+        return jsonSerializerOptions;
+    }
 }

--- a/Unity.Mathematics.Text.Json/JsonSerializerOptions/ObjectJsonSerializerOptions.cs
+++ b/Unity.Mathematics.Text.Json/JsonSerializerOptions/ObjectJsonSerializerOptions.cs
@@ -5,73 +5,75 @@ namespace Unity.Mathematics.Text.Json;
 public static class Object
 {
     public static readonly JsonSerializerOptions JsonSerializerOptions =
-        new()
-        {
-            MaxDepth = 1024,
-            WriteIndented = true,
-            Converters =
-            {
-                new Float2JsonObjectConverter(),
-                new Float3JsonObjectConverter(),
-                new Float4JsonObjectConverter(),
-                new QuaternionJsonObjectConverter(),
-                new Float2x2JsonObjectConverter(),
-                new Float2x3JsonObjectConverter(),
-                new Float2x4JsonObjectConverter(),
-                new Float3x2JsonObjectConverter(),
-                new Float3x3JsonObjectConverter(),
-                new Float3x4JsonObjectConverter(),
-                new Float4x2JsonObjectConverter(),
-                new Float4x3JsonObjectConverter(),
-                new Float4x4JsonObjectConverter(),
-                new Int2JsonObjectConverter(),
-                new Int3JsonObjectConverter(),
-                new Int4JsonObjectConverter(),
-                new Int2x2JsonObjectConverter(),
-                new Int2x3JsonObjectConverter(),
-                new Int2x4JsonObjectConverter(),
-                new Int3x2JsonObjectConverter(),
-                new Int3x3JsonObjectConverter(),
-                new Int3x4JsonObjectConverter(),
-                new Int4x2JsonObjectConverter(),
-                new Int4x3JsonObjectConverter(),
-                new Int4x4JsonObjectConverter(),
-                new Uint2JsonObjectConverter(),
-                new Uint3JsonObjectConverter(),
-                new Uint4JsonObjectConverter(),
-                new Uint2x2JsonObjectConverter(),
-                new Uint2x3JsonObjectConverter(),
-                new Uint2x4JsonObjectConverter(),
-                new Uint3x2JsonObjectConverter(),
-                new Uint3x3JsonObjectConverter(),
-                new Uint3x4JsonObjectConverter(),
-                new Uint4x2JsonObjectConverter(),
-                new Uint4x3JsonObjectConverter(),
-                new Uint4x4JsonObjectConverter(),
-                new Double2JsonObjectConverter(),
-                new Double3JsonObjectConverter(),
-                new Double4JsonObjectConverter(),
-                new Double2x2JsonObjectConverter(),
-                new Double2x3JsonObjectConverter(),
-                new Double2x4JsonObjectConverter(),
-                new Double3x2JsonObjectConverter(),
-                new Double3x3JsonObjectConverter(),
-                new Double3x4JsonObjectConverter(),
-                new Double4x2JsonObjectConverter(),
-                new Double4x3JsonObjectConverter(),
-                new Double4x4JsonObjectConverter(),
-                new Bool2JsonObjectConverter(),
-                new Bool3JsonObjectConverter(),
-                new Bool4JsonObjectConverter(),
-                new Bool2x2JsonObjectConverter(),
-                new Bool2x3JsonObjectConverter(),
-                new Bool2x4JsonObjectConverter(),
-                new Bool3x2JsonObjectConverter(),
-                new Bool3x3JsonObjectConverter(),
-                new Bool3x4JsonObjectConverter(),
-                new Bool4x2JsonObjectConverter(),
-                new Bool4x3JsonObjectConverter(),
-                new Bool4x4JsonObjectConverter()
-            }
-        };
+        CreateJsonObjectSerializerOptions();
+
+    private static JsonSerializerOptions CreateJsonObjectSerializerOptions()
+    {
+        JsonSerializerOptions jsonSerializerOptions =
+            new() { MaxDepth = 1024, WriteIndented = true, };
+
+        jsonSerializerOptions.Converters.Add(new Float2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new QuaternionJsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float2x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float3x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Float4x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int2x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int3x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Int4x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint2x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint3x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Uint4x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double2x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double3x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Double4x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool2x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool3x4JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x2JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x3JsonObjectConverter());
+        jsonSerializerOptions.Converters.Add(new Bool4x4JsonObjectConverter());
+
+        return jsonSerializerOptions;
+    }
 }


### PR DESCRIPTION
- **refactor (Unity.Mathematics.Text.Json): create Array.JsonSerializerOptions from CreateJsonArraySerializerOptions() factory method**
- **refactor (Unity.Mathematics.Text.Json): create Object.JsonSerializerOptions from CreateJsonObjectSerializerOptions() factory method**
- **refactor (Unity.Mathematics.Text.Json.ArrayNotation): create Profile.JsonSerializerOptions from CreateJsonSerializerOptions() factory method**
- **refactor (Unity.Mathematics.Text.Json.ObjectNotation): create Profile.JsonSerializerOptions from CreateJsonSerializerOptions() factory method**
